### PR TITLE
chore: centralize files to org level repo

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality concerning the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at <https://www.contributor-covenant.org/version/1/4/code-of-conduct.html>
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+<https://www.contributor-covenant.org/faq>

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# **Contributing**
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change.
+
+Please note we have a [code of conduct](CODE_OF_CONDUCT.md); please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a
+   build.
+2. Update the README.md with details of changes to the interface; this includes new environment variables, exposed ports, valid file locations and container parameters.
+3. Increase the version numbers in any examples files and the README.md to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. You may merge the Pull Request once you have the sign-off of two other developers, or if you
+   do not have permission to do that, you may request the second reviewer to merge it for you.
+
+## Issue Report Process
+
+1. Go to the project's issues.
+2. Select the template that better fits your issue.
+3. Read the instructions carefully and write within the template guidelines.
+4. Submit it and wait for support.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy for Privateer
+
+Version: **v0.1 (2023-08-14)**
+
+## Preface
+
+Privateer currently only supports non-production use cases. But in spite of that, the Privateer Project team places high value on security considerations, and is continuously working on improving it.
+
+## Supported Versions
+
+Until the official v1 release, we will not support any versions prior to the latest minor version. For example, we will add security patches to v0.3 until v0.4 is released. This documentation will be updated with the release of v1.
+
+## Reporting a Vulnerability
+
+If you find a security related bug in Privateer, we kindly ask you for 
+responsible disclosure and for giving us appropriate time to react, analyze and 
+develop a fix to mitigate the found security vulnerability.
+
+We will do our best to react quickly on your inquiry, and to coordinate a fix
+and disclosure with you. Sometimes, it might take a little longer for us to
+react (e.g. out of office conditions), so please bear with us in these cases.
+
+We will publish security advisories using the
+GitHub Security Advisories feature for each repository: <https://github.com/privateerproj/[repository_name]/security/advisories> (i.e., <https://github.com/privateerproj/privateer/security/advisories>).
+feature to keep our community well-informed, and will credit you for your
+findings (unless you prefer to stay anonymous, of course).

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# All PRs in this repository will be blocked until they
+# have been approved by the respective code owner
+
+* @privateerproj/core-maintainers


### PR DESCRIPTION
By putting these files in the .github folder in this .github repo, these files will automatically propogate down to all org repositories

If the repo has their own version it will replace these