### PR TITLE
fix: use octo-sts token for OSPS scanner admin-level API access

### DIFF
--- a/.github/chainguard/.github.sts.yaml
+++ b/.github/chainguard/.github.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:privateerproj/.github:(pull_request|ref:refs/heads/.+)"
+claim_pattern:
+  job_workflow_ref: "^privateerproj/.github/.github/workflows/osps-security-assessment.yml@refs/(heads/.+|pull/[0-9]+/merge)$"
+
+permissions:
+  contents: read
+  statuses: read
+  deployments: read
+  security_events: read
+  administration: read

--- a/.github/workflows/osps-security-assessment.yml
+++ b/.github/workflows/osps-security-assessment.yml
@@ -13,6 +13,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write # Required for octo-sts OIDC token exchange
       security-events: write # Required for SARIF upload
 
     steps:
@@ -21,12 +22,18 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05
+        id: octo-sts
+        with:
+          scope: privateerproj/.github
+          identity: .github
+
       - name: Open Source Project Security Baseline Scanner
         uses: revanite-io/osps-baseline-action@6d2d044b2ec5299d4d8b82da3027c7f5ddadda6e
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.octo-sts.outputs.token }}
           catalog: "osps-baseline"
           upload-sarif: "true"
 


### PR DESCRIPTION
## What

Added octo-sts OIDC token exchange to the OSPS security assessment workflow and configured the STS trust policy. The scanner now uses the octo-sts minted token instead of GITHUB_TOKEN.

## Why

The OSPS scanner reads the repository's security_and_analysis field from the GitHub API, which requires administration:read permission. GITHUB_TOKEN cannot be granted this permission, so the scanner was reporting secret scanning as disabled despite it being enabled.

## Notes

- The STS policy file at .github/chainguard/.github.sts.yaml must be merged to the default branch before octo-sts can resolve the identity
- The octo-sts GitHub App must be installed on the privateerproj org for the OIDC exchange to work
- id-token:write permission is required at the job level for the OIDC token request to GitHub's token endpoint