### PR TITLE
Add org-level security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Supported Versions
+
+We provide security updates for the latest released version of each project in the [privateerproj](https://github.com/privateerproj) organization. Older versions do not receive backported fixes.
+
+| Version       | Supported |
+|---------------|-----------|
+| Latest release | Yes      |
+| Older releases | No       |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in any repository under the `privateerproj` organization, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please use [GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) on the affected repository. This allows maintainers to assess and address the issue before public disclosure.
+
+### What to include
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce the issue
+- Any relevant logs, screenshots, or proof-of-concept code
+- Your suggested fix, if you have one
+
+### What to expect
+
+- **Acknowledgment** within 5 business days of your report
+- **Status update** within 15 business days with an assessment and remediation plan
+- **Credit** in the advisory and release notes (unless you prefer to remain anonymous)
+
+We ask that you give us reasonable time to address the issue before any public disclosure.
+
+## Scope
+
+This policy applies to all repositories under the [privateerproj](https://github.com/privateerproj) GitHub organization, including but not limited to:
+
+- [privateer](https://github.com/privateerproj/privateer) (core CLI)
+- [privateer-sdk](https://github.com/privateerproj/privateer-sdk) (SDK)
+- Community and example plugins
+
+## Security Best Practices
+
+All contributions to privateerproj repositories undergo code review before merging. We use GitHub's Dependabot for automated dependency vulnerability scanning across our repositories.


### PR DESCRIPTION
## What

Adds a SECURITY.md to the org-level .github repo, establishing a vulnerability reporting and response policy that applies to all repositories in the privateerproj organization.

## Why

Needed as part of the OpenSSF Sandbox application (privateerproj/privateer#271). The application template requires a SECURITY.md link, and having a clear security policy strengthens the submission.

## Notes

- This uses GitHub's private vulnerability reporting as the sole reporting channel. A fallback email can be added later if needed.
- Response timelines (5 day ack, 15 day status update) are standard but worth confirming the team can commit to them.
- Applies org-wide via GitHub's community health file inheritance.