### PR TITLE
fix(ci): use dated osps-baseline-2026-02 catalog

### DIFF
--- a/.github/workflows/osps-security-assessment.yml
+++ b/.github/workflows/osps-security-assessment.yml
@@ -34,7 +34,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
           token: ${{ steps.octo-sts.outputs.token }}
-          catalog: "osps-baseline"
+          catalog: "osps-baseline-2026-02"
           upload-sarif: "true"
 
       - name: Upload Assessment Results


### PR DESCRIPTION
## What/Why
The weekly OSPS Security Assessment job fails because the scanner (pvtr v0.22.0) no longer recognizes the bare `osps-baseline` catalog name, so it evaluates zero controls and exits 1. Pinning the dated `osps-baseline-2026-02` catalog restores results.

## Proof it works
- Failing run [29248868574](https://github.com/privateerproj/.github/actions/runs/29248868574) errored with `OSPS scanner produced no control results — check catalog name and scanner configuration`.
- `privateerproj/privateer` already runs green with `osps-baseline-2026-02` on the same action pin and scanner image.
- Workflow YAML validated locally with `yaml.safe_load`.
- Will confirm via `workflow_dispatch` after merge.

## Risk + AI role
Low -- CI-only workflow config, no runtime impact. Diagnosis and change AI-assisted.

## Review focus
Whether pinning to a dated catalog snapshot is preferred over tracking the latest name, given it will need periodic bumps as new dated catalogs publish.